### PR TITLE
Fixed typos found in spark-shell version

### DIFF
--- a/spark-kudu examples/scala-kudu/kudu.scala
+++ b/spark-kudu examples/scala-kudu/kudu.scala
@@ -50,7 +50,7 @@ val kuduTableSchema = StructType(
 val kuduPrimaryKey = Seq("name")
 
 // Step 7
-val kuduTableOptions = new CreateTableOption()
+val kuduTableOptions = new CreateTableOptions()
 
 // Step 8
 kuduTableOptions.setRangePartitionColumns(List("name").asJava).setNumReplicas(3)
@@ -77,7 +77,7 @@ val customersRDD = sc.parallelize(customers)
 val customersDF = spark.createDataFrame(customersRDD)
 
 // Step 5
-kuduContext.insertRows(df, kuduTableName) 
+kuduContext.insertRows(customersDF, kuduTableName) 
 
 // OPTIONAL: Step 6
 // spark.read.options(kuduOptions).kudu.show()


### PR DESCRIPTION
 - CreateTableOption() => CreateTableOptions()
 - df => customersDF