### PR TITLE
Patch 1

### DIFF
--- a/spark-kudu examples/scala-kudu/README.md
+++ b/spark-kudu examples/scala-kudu/README.md
@@ -2,9 +2,18 @@
 
 Adapted from [here](https://blog.cloudera.com/blog/2017/02/up-and-running-with-apache-spark-on-apache-kudu/)
 
-## Part 0: Kerberos
+## Part 0: Kerberos & Spark-Shell
 
 Once you have used `ssh` to get in, use `$ kinit user` to gain permission. You will then be prompted to enter your password. Check using `$klist` to see if it's there
+
+To start up the spark-shell, use the following command:
+```
+spark2-shell \
+  --packages org.apache.kudu:kudu-spark2_2.11:1.6.0 \
+  --conf spark.driver.allowMultipleContexts=true
+```
+
+That will automatically import certain dependencies.
 
 ---
 
@@ -274,6 +283,7 @@ The following dependencies are required upon the dependencies listed at the top
 ```scala
 import org.apache.kudu.client.KuduClient
 import org.apache.kudu.client.AlterTableOptions
+import org.apache.kudu.Type
 ```
 
 ### Step 2: Create a new Kudu Client
@@ -286,7 +296,7 @@ val client = new KuduClient.KuduClientBuilder("master-ip").defaultAdminOperation
 ```
 
 ### **Step 3:** Create object for defaultVal
-One of `AlterTableOption()`'s parameters is defaultVal. To supply this, create an objec:
+One of `AlterTableOption()`'s parameters is defaultVal, or default value. This will be inserted as the default value when you add the table. In this case, it's a long 0.To supply this, create an object:
 ```scala
 val o = 0l;
 ```
@@ -307,4 +317,10 @@ client.alterTable(kuduTableName, new AlterTableOptions()
     .addNullableColumn("addNullable", Type.INT32)
 )
 ```
-The types that you can use are listed [here](https://www.cloudera.com/documentation/enterprise/5-14-x/topics/kudu_schema_design.html).
+The types that you can use are listed [here](https://kudu.apache.org/apidocs/org/apache/kudu/Type.html).
+
+### **Optional Step 5**: Read the table
+To read the table, do the following:
+```scala
+spark.read.options(kuduOptions).kudu.show()
+```

--- a/spark-kudu examples/scala-kudu/kudu.scala
+++ b/spark-kudu examples/scala-kudu/kudu.scala
@@ -95,7 +95,7 @@ customersDF.registerTempTable("customers")
 val deleteKeysDF = sqlContext.sql("select name from customers where age > 20")
 
 // Step 3
-kuduContext.deleteRows(deleteKeyasDF, kuduTableName)
+kuduContext.deleteRows(deleteKeysDF, kuduTableName)
 
 // Optional Step 4
 // sqlContext.read.options(kuduOptions).kudu.show
@@ -142,6 +142,7 @@ kuduContext.updateRows(modifiedCustomersDF, kuduTableName)
 // Step 1
 import org.apache.kudu.client.KuduClient
 import org.apache.kudu.client.AlterTableOptions
+import org.apache.kudu.Type
 
 // Step 2
 val client = new KuduClient.KuduClientBuilder("master-ip").defaultAdminOperationTimeoutMs(600000).build()
@@ -151,3 +152,6 @@ val o = 0l;
 
 // Step 4
 client.alterTable(kuduTableName, new AlterTableOptions().addColumn("column-name", type, o))
+
+// Optional Step 5
+// sqlContext.read.options(kuduOptions).kudu.show

--- a/spark-kudu examples/scala-kudu/scala-spark-shell.scala
+++ b/spark-kudu examples/scala-kudu/scala-spark-shell.scala
@@ -120,3 +120,19 @@ kuduContext.updateRows(modifiedCustomersDF, kuduTableName)
 
 // Optional Step 5
 // sqlContext.read.options(kuduOptions).kudu.show
+
+// PART 6: Alter Table
+// Step 1
+import org.apache.kudu.client.KuduClient, org.apache.kudu.client.AlterTableOptions, org.apache.kudu.Type
+
+// Step 2
+val client = new KuduClient.KuduClientBuilder("master-ip").defaultAdminOperationTimeoutMs(600000).build()
+
+// Step 3
+val o = 0l;
+
+// Step 4
+client.alterTable(kuduTableName, new AlterTableOptions().addColumn("column-name", type, o))
+
+// Optional Step 5
+// sqlContext.read.options(kuduOptions).kudu.show

--- a/spark-kudu examples/scala-kudu/scala-spark-shell.scala
+++ b/spark-kudu examples/scala-kudu/scala-spark-shell.scala
@@ -82,7 +82,7 @@ customersDF.registerTempTable("customers")
 val deleteKeysDF = sqlContext.sql("select name from customers where age > 20")
 
 // Step 3
-kuduContext.deleteRows(deleteKeyasDF, kuduTableName)
+kuduContext.deleteRows(deleteKeysDF, kuduTableName)
 
 // Optional Step 4
 // sqlContext.read.options(kuduOptions).kudu.show


### PR DESCRIPTION
**Added Spark Shell Command**:
```
spark2-shell \
  --packages org.apache.kudu:kudu-spark2_2.11:1.6.0 \
  --conf spark.driver.allowMultipleContexts=true
```

**Added Type Imports**:
```scala
import org.apache.kudu.Type
```
Updated in README.md, kudu.scala, and scala-spark-shell.kudu

**Fixed Typos**:
 - `deleteKeyasDF` → `deleteKeysDF` in `kudu.scala` and `scala-spark-shell.scala`
 - `NewAndChangedRDD` → `newAndChangedRDD` in `README.md`

**Added Clarification to README.md**:
 - Added extra information about TGT & Kerberos
 - Updated the format of the master to be more general
 - Updated link in Schema creation to point towards the kudu documentation
 - Updated name for part 2.1 from `Case Class` to `Define a Case Class`
 - Changed `customer` to `customers` in part 2.2

**Added Read Table Option**:
 - Updated part 6 to include an optional step to read the table (to test if the alter worked)

**Updated Type Links**:
 - Changed the link in part 6 from the list supplied by Cloudera to the one by the kudu API docs

